### PR TITLE
Make values configurable through environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Adds fading between windows in Swaywm.
 4. add `exec python3 /path/to/swayfader.py` to your sway config to have the program launch at startup. Alternatively, run `python3 /path/to/swayfader.py` to start the program manually.
 
 ### Configuration
-You can play around with the variables at the top of the file to configure opacities and fade durations. `CON` refers to a normal tiled window, while `BOT` refers to a tiled window that has just lost focus to a floating window. Everything else should be self-explanatory.
+The opacities and fade durations can be configured through environment variables. For example, `SWAYFADER_CON_INAC` for inactive window opacity. When not set, the values have sane defaults.
+
+`CON` refers to a normal tiled window, while `BOT` refers to a tiled window that has just lost focus to a floating window. Everything else should be self-explanatory.

--- a/swayfader.py
+++ b/swayfader.py
@@ -3,32 +3,33 @@
 from i3ipc import Connection, Event
 from threading import Thread
 from time import sleep
+from os import getenv
 
 # delay per frame
-FRAME_T = 0.01
+FRAME_T = int(getenv("SWAYFADER_FRAME_T", 0.01))
 
 # transparency values
-CON_AC     = 1     # active window
-CON_INAC   = 0.7   # inactive window
-FLOAT_AC   = 1     # active floating window
-FLOAT_INAC = 0.95  # inactive floating window
-BOT_INAC   = 0.9   # bottom window
+CON_AC     = int(getenv("SWAYFADER_CON_AC", 1))        # active window
+CON_INAC   = int(getenv("SWAYFADER_CON_INAC", 0.7))    # inactive window
+FLOAT_AC   = int(getenv("SWAYFADER_FLOAT_AC", 1))      # active floating window
+FLOAT_INAC = int(getenv("SWAYFADER_FLOAT_INAC", 0.95)) # inactive floating window
+BOT_INAC   = int(getenv("SWAYFADER_BOT_INAC", 0.9))    # bottom window
 
 
 # fade durations
-FADE_TIME      = 0.2
-ALT_FADE_TIME  = 0.1
+FADE_TIME      = int(getenv("SWAYFADER_FADE_TIME", 0.2))
+ALT_FADE_TIME  = int(getenv("SWAYFADER_ALT_FADE_TIME", 0.1))
 
-CON_OUT        = FADE_TIME      # window fading out
-CON_IN         = 0.15           # window fading in
-FLOAT_OUT      = ALT_FADE_TIME  # floating window fading out
-FLOAT_IN       = ALT_FADE_TIME  # floating window fading in
-BOT_OUT        = ALT_FADE_TIME  # bottom window fading out
-BOT_IN         = ALT_FADE_TIME  # bottom window fading in
-BOT_SWITCH_IN  = FADE_TIME      # window becoming bottom window
-BOT_SWITCH_OUT = FADE_TIME      # bottom window becoming window
-FLOAT_BOT_OUT  = FADE_TIME      # floating window fading out from bottom
-FLOAT_BOT_IN   = FADE_TIME      # floating window fading in from bottom
+CON_OUT        = int(getenv("SWAYFADER_CON_OUT", FADE_TIME))        # window fading out
+CON_IN         = int(getenv("SWAYFADER_CON_IN", FADE_TIME-0.05))    # window fading in
+FLOAT_OUT      = int(getenv("SWAYFADER_FLOAT_OUT", ALT_FADE_TIME))  # floating window fading out
+FLOAT_IN       = int(getenv("SWAYFADER_FLOAT_IN", ALT_FADE_TIME))   # floating window fading in
+BOT_OUT        = int(getenv("SWAYFADER_BOT_OUT", ALT_FADE_TIME))    # bottom window fading out
+BOT_IN         = int(getenv("SWAYFADER_BOT_IN", ALT_FADE_TIME))     # bottom window fading in
+BOT_SWITCH_IN  = int(getenv("SWAYFADER_BOT_SWITCH_IN", FADE_TIME))  # window becoming bottom window
+BOT_SWITCH_OUT = int(getenv("SWAYFADER_BOT_SWITCH_OUT", FADE_TIME)) # bottom window becoming window
+FLOAT_BOT_OUT  = int(getenv("SWAYFADER_FLOAT_BOT_OUT", FADE_TIME))  # floating window fading out from bottom
+FLOAT_BOT_IN   = int(getenv("SWAYFADER_FLOAT_BOT_IN", FADE_TIME))   # floating window fading in from bottom
 
 
 class Fader:

--- a/swayfader.py
+++ b/swayfader.py
@@ -6,30 +6,30 @@ from time import sleep
 from os import getenv
 
 # delay per frame
-FRAME_T = int(getenv("SWAYFADER_FRAME_T", 0.01))
+FRAME_T = float(getenv("SWAYFADER_FRAME_T", 0.01))
 
 # transparency values
-CON_AC     = int(getenv("SWAYFADER_CON_AC", 1))        # active window
-CON_INAC   = int(getenv("SWAYFADER_CON_INAC", 0.7))    # inactive window
-FLOAT_AC   = int(getenv("SWAYFADER_FLOAT_AC", 1))      # active floating window
-FLOAT_INAC = int(getenv("SWAYFADER_FLOAT_INAC", 0.95)) # inactive floating window
-BOT_INAC   = int(getenv("SWAYFADER_BOT_INAC", 0.9))    # bottom window
+CON_AC     = float(getenv("SWAYFADER_CON_AC", 1))        # active window
+CON_INAC   = float(getenv("SWAYFADER_CON_INAC", 0.7))    # inactive window
+FLOAT_AC   = float(getenv("SWAYFADER_FLOAT_AC", 1))      # active floating window
+FLOAT_INAC = float(getenv("SWAYFADER_FLOAT_INAC", 0.95)) # inactive floating window
+BOT_INAC   = float(getenv("SWAYFADER_BOT_INAC", 0.9))    # bottom window
 
 
 # fade durations
-FADE_TIME      = int(getenv("SWAYFADER_FADE_TIME", 0.2))
-ALT_FADE_TIME  = int(getenv("SWAYFADER_ALT_FADE_TIME", 0.1))
+FADE_TIME      = float(getenv("SWAYFADER_FADE_TIME", 0.2))
+ALT_FADE_TIME  = float(getenv("SWAYFADER_ALT_FADE_TIME", 0.1))
 
-CON_OUT        = int(getenv("SWAYFADER_CON_OUT", FADE_TIME))        # window fading out
-CON_IN         = int(getenv("SWAYFADER_CON_IN", FADE_TIME-0.05))    # window fading in
-FLOAT_OUT      = int(getenv("SWAYFADER_FLOAT_OUT", ALT_FADE_TIME))  # floating window fading out
-FLOAT_IN       = int(getenv("SWAYFADER_FLOAT_IN", ALT_FADE_TIME))   # floating window fading in
-BOT_OUT        = int(getenv("SWAYFADER_BOT_OUT", ALT_FADE_TIME))    # bottom window fading out
-BOT_IN         = int(getenv("SWAYFADER_BOT_IN", ALT_FADE_TIME))     # bottom window fading in
-BOT_SWITCH_IN  = int(getenv("SWAYFADER_BOT_SWITCH_IN", FADE_TIME))  # window becoming bottom window
-BOT_SWITCH_OUT = int(getenv("SWAYFADER_BOT_SWITCH_OUT", FADE_TIME)) # bottom window becoming window
-FLOAT_BOT_OUT  = int(getenv("SWAYFADER_FLOAT_BOT_OUT", FADE_TIME))  # floating window fading out from bottom
-FLOAT_BOT_IN   = int(getenv("SWAYFADER_FLOAT_BOT_IN", FADE_TIME))   # floating window fading in from bottom
+CON_OUT        = float(getenv("SWAYFADER_CON_OUT", FADE_TIME))        # window fading out
+CON_IN         = float(getenv("SWAYFADER_CON_IN", FADE_TIME-0.05))    # window fading in
+FLOAT_OUT      = float(getenv("SWAYFADER_FLOAT_OUT", ALT_FADE_TIME))  # floating window fading out
+FLOAT_IN       = float(getenv("SWAYFADER_FLOAT_IN", ALT_FADE_TIME))   # floating window fading in
+BOT_OUT        = float(getenv("SWAYFADER_BOT_OUT", ALT_FADE_TIME))    # bottom window fading out
+BOT_IN         = float(getenv("SWAYFADER_BOT_IN", ALT_FADE_TIME))     # bottom window fading in
+BOT_SWITCH_IN  = float(getenv("SWAYFADER_BOT_SWITCH_IN", FADE_TIME))  # window becoming bottom window
+BOT_SWITCH_OUT = float(getenv("SWAYFADER_BOT_SWITCH_OUT", FADE_TIME)) # bottom window becoming window
+FLOAT_BOT_OUT  = float(getenv("SWAYFADER_FLOAT_BOT_OUT", FADE_TIME))  # floating window fading out from bottom
+FLOAT_BOT_IN   = float(getenv("SWAYFADER_FLOAT_BOT_IN", FADE_TIME))   # floating window fading in from bottom
 
 
 class Fader:


### PR DESCRIPTION
Hey!

This PR makes swayfader configurable through environment variales. This is useful for changing them out without modifying the source code (e.g. when it is installed as a system package).

All values have a default fallback (exactly as they are today) when the respective env var is not present.